### PR TITLE
Provide calendars for custom meal types

### DIFF
--- a/custom_components/paprika/calendar.py
+++ b/custom_components/paprika/calendar.py
@@ -28,13 +28,13 @@ class PaprikaMealCalendar(CalendarEntity, CoordinatorEntity["PaprikaCoordinator"
     ):
         super().__init__(coordinator)
         self.meal_type = meal_type
-        self._attr_unique_id = f"{entry.title}_calendar_{self.meal_type.name}"
+        self._attr_unique_id = f"{entry.title}_calendar_{self.meal_type['name']}"
         self._attr_has_entity_name = False
 
     @property
     def name(self):
         """Name of the entity."""
-        return f"Paprika {self.meal_type.name}"
+        return f"Paprika {self.meal_type['name']}"
 
     @property
     def event(self):
@@ -97,22 +97,8 @@ async def async_setup_entry(
             PaprikaMealCalendar(
                 coordinator=entry.runtime_data.coordinator,
                 entry=entry,
-                meal_type=MealType.Dinner,
-            ),
-            PaprikaMealCalendar(
-                coordinator=entry.runtime_data.coordinator,
-                entry=entry,
-                meal_type=MealType.Lunch,
-            ),
-            PaprikaMealCalendar(
-                coordinator=entry.runtime_data.coordinator,
-                entry=entry,
-                meal_type=MealType.Breakfast,
-            ),
-            PaprikaMealCalendar(
-                coordinator=entry.runtime_data.coordinator,
-                entry=entry,
-                meal_type=MealType.Snack,
-            ),
+                meal_type=mt,
+            )
+            for mt in entry.runtime_data.coordinator.data.meal_types
         ]
     )

--- a/custom_components/paprika/coordinator.py
+++ b/custom_components/paprika/coordinator.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 if TYPE_CHECKING:
-    from .api import GroceryListItem, PlannedMeal
+    from .api import GroceryListItem, MealType, PlannedMeal
     from .data import PaprikaConfigEntry
 
 
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
 class PaprikaData:
     meals: list["PlannedMeal"]
     groceries: list["GroceryListItem"]
+    meal_types: list["MealType"]
 
 
 class PaprikaCoordinator(DataUpdateCoordinator[PaprikaData]):
@@ -21,6 +22,7 @@ class PaprikaCoordinator(DataUpdateCoordinator[PaprikaData]):
 
     async def _async_update_data(self) -> Any:
         """Update data via library."""
-        meals = await self.config_entry.runtime_data.client.get_meals()
+        meal_types = await self.config_entry.runtime_data.client.get_meal_types()
+        meals = await self.config_entry.runtime_data.client.get_meals(meal_types)
         groceries = await self.config_entry.runtime_data.client.get_groceries()
-        return PaprikaData(meals=meals, groceries=groceries)
+        return PaprikaData(meal_types=meal_types, meals=meals, groceries=groceries)


### PR DESCRIPTION
Previously we were hard-coding the meal names, which meant that if a user had renamed them in the app they wouldn't work, and if they had added new custom meal types, they also wouldn't show up. 

This change adds a query to the meal_types endpoint before getting the meal plans so that we can create a calendar per meal type.