### PR TITLE
Skip old planned meals during download to avoid a crash for some accounts

### DIFF
--- a/custom_components/paprika/api.py
+++ b/custom_components/paprika/api.py
@@ -7,7 +7,9 @@ import aiohttp
 
 _LOGGER = logging.getLogger(__name__)
 
-START_DATE_FILTER = date(2025, 1, 1)  # Only process meals after this date (see issue #13)
+START_DATE_FILTER = date(
+    2025, 1, 1
+)  # Only process meals after this date (see issue #13)
 
 MealId = NewType("MealId", str)
 RecipeID = NewType("RecipeID", str)
@@ -101,10 +103,12 @@ class PaprikaApi:
             meal_date = datetime.strptime(meal["date"][:10], "%Y-%m-%d").date()
             # Skip meals before START_DATE_FILTER to avoid processing old data with bad ids (see issue #13)
             if meal_date < START_DATE_FILTER:
+                _LOGGER.debug("Skipping meal with date before cutoff: %s", meal)
                 continue
             meal["date"] = meal_date
             meal["type"] = meal_types_by_id[meal["type_uid"]]
             meals.append(cast("PlannedMeal", meal))
+        _LOGGER.debug("Got %s meals from API", len(meals))
         return meals
 
     async def get_groceries(self) -> list[GroceryListItem]:


### PR DESCRIPTION
Older planned meals coming from the paprika api don't have correctly linked up meal types in their responses due to a change to the paprika api a while ago. This was making the integration crash for some users.

This change makes the integration only load planned meals from the start of 2025 onwards, which should address the issue.

Addresses Issue: Not able to set up integration #13